### PR TITLE
Reload song from disk patch

### DIFF
--- a/VocaluxeLib/Songs/CSong.cs
+++ b/VocaluxeLib/Songs/CSong.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 // This file is part of Vocaluxe.
 // 
 // Vocaluxe is free software: you can redistribute it and/or modify
@@ -285,6 +285,14 @@ namespace VocaluxeLib.Songs
         {
             var loader = new CSongLoader(this);
             return loader.ReadNotes();
+        }
+
+        public bool ReloadSong()
+        {
+            var loader = new CSongLoader(this);
+            bool retValue = loader.ReadHeader();
+            retValue = loader.ReadNotes(true);
+            return retValue;
         }
 
         public bool Save()

--- a/VocaluxeLib/Songs/CSongLoader.cs
+++ b/VocaluxeLib/Songs/CSongLoader.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 // This file is part of Vocaluxe.
 // 
 // Vocaluxe is free software: you can redistribute it and/or modify
@@ -110,6 +110,9 @@ namespace VocaluxeLib.Songs
                 _Song._CalculateMedley = true;
                 _Song.Preview.Source = EDataSource.None;
                 _Song.ShortEnd.Source = EDataSource.None;
+                _Song.Start = 0;
+                _Song.VideoGap = 0;
+                _Song.Preview.StartTime = 0;
 
                 var headerFlags = new EHeaderFlags();
                 StreamReader sr = null;


### PR DESCRIPTION
Backported some stuff from develop branch to restart the current game and added some "reload from disk" stuff.

This changes will reload the current txt file from disk every time a song will be started. Also added key shortcut (F5 and CTRL + R) in pause menu on sing screen to restart the current song while reloading it from disk. This makes song editing much more easier.

Not tested all aspects, there might be txt file changes, which will not work. Please report bugs and stuff like that.